### PR TITLE
Fix broken CI (infection)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ on:
     - cron: '0 16 * * 0' # sunday 16:00
 
 jobs:
-
   phpcs:
-    name: PHP Code Sniffer
+    name: Coding standards (phpcs)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -24,11 +23,11 @@ jobs:
         env:
           fail-fast: true
 
-      - name: Code style (phpcs)
+      - name: Coding standards (phpcs)
         run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
-    name: PHP Coding Standards Fixer
+    name: Coding standards (php-cs-fixer)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -36,17 +35,17 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.0' # cannot use php 8.0 because phpunit dependency
+          php-version: '8.0'
           coverage: none
           tools: composer:v2, cs2pr, php-cs-fixer
         env:
           fail-fast: true
 
-      - name: Code style (php-cs-fixer)
+      - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   phpunit:
-    name: PHPUnit on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-versions }} (phpunit)
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -77,11 +76,11 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
-      - name: Tests
+      - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
 
   phpstan:
-    name: PHP Static Analysis Tool
+    name: Static analysis (phpstan)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -109,11 +108,11 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
-      - name: Code analysis (phpstan)
+      - name: Static analysis (phpstan)
         run: phpstan analyse --no-progress --verbose
 
   psalm:
-    name: Psalm
+    name: Static analysis (psalm)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -141,11 +140,11 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
-      - name: Code analysis (psalm)
+      - name: Static analysis (psalm)
         run: psalm --no-progress
 
   infection:
-    name: PHP Mutation Testing Framework
+    name: Mutation Testing (infection)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '7.4' # cannot use php 8.0 because phpunit dependency
           extensions: filter, fileinfo, dom
           coverage: xdebug
-          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm, infection
+          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
         env:
           fail-fast: true
 
@@ -62,7 +62,10 @@ jobs:
         run: psalm --no-progress
 
       - name: Mutation testing (infection)
-        run: infection --no-progress --no-interaction --show-mutations --logger-github
+        # run this way because infection phar is not working on php 7.4
+        run: |
+          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
+          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github
 
       # see https://github.com/marketplace/actions/action-scrutinizer
       - name: Upload code coverage to scrutinizer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,92 +1,65 @@
 name: build
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
   push:
-    branches:
-      - main
+    branches: [ main ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
 jobs:
 
-  ci: # this job runs all the development tools and upload code coverage to scrutinizer
-
-    name: Continuous Integration
+  phpcs:
+    name: PHP Code Sniffer
     runs-on: "ubuntu-latest"
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '7.4' # cannot use php 8.0 because phpunit dependency
-          coverage: xdebug
-          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, phpcs
         env:
           fail-fast: true
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
 
       - name: Code style (phpcs)
         run: phpcs -q --report=checkstyle | cs2pr
 
+  php-cs-fixer:
+    name: PHP Coding Standards Fixer
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.0' # cannot use php 8.0 because phpunit dependency
+          coverage: none
+          tools: composer:v2, cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
-      - name: Tests (phpunit with code coverage)
-        run: vendor/bin/phpunit --testdox --verbose
-
-      - name: Code analysis (phpstan)
-        run: phpstan analyse --no-progress --verbose
-
-      - name: Code analysis (psalm)
-        run: psalm --no-progress
-
-      - name: Mutation testing (infection)
-        # run this way because infection phar is not working on php 7.4
-        run: |
-          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
-          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github
-
-  build:
-
-    name: PHP ${{ matrix.php-versions }}
+  phpunit:
+    name: PHPUnit on PHP ${{ matrix.php-versions }}
     runs-on: "ubuntu-latest"
-
     strategy:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0']
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2
         env:
           fail-fast: true
 
@@ -106,3 +79,103 @@ jobs:
 
       - name: Tests
         run: vendor/bin/phpunit --testdox --verbose
+
+  phpstan:
+    name: PHP Static Analysis Tool
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, phpstan
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+
+      - name: Code analysis (phpstan)
+        run: phpstan analyse --no-progress --verbose
+
+  psalm:
+    name: Psalm
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, psalm
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+
+      - name: Code analysis (psalm)
+        run: psalm --no-progress
+
+  infection:
+    name: PHP Mutation Testing Framework
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '7.4' # cannot use php 8.0 because phpunit compatibility
+          coverage: xdebug
+          tools: composer:v2
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+
+      - name: Mutation testing (infection)
+        # run this way because infection phar is not working on php 7.4
+        run: |
+          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
+          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4' # cannot use php 8.0 because phpunit dependency
-          extensions: filter, fileinfo, dom
           coverage: xdebug
           tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
         env:
@@ -93,7 +92,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: filter, fileinfo, dom
           coverage: none
           tools: composer:v2, cs2pr
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
       - name: Tests (phpunit with code coverage)
-        run: vendor/bin/phpunit --testdox --verbose --coverage-clover=build/coverage-clover.xml
+        run: vendor/bin/phpunit --testdox --verbose
 
       - name: Code analysis (phpstan)
         run: phpstan analyse --no-progress --verbose
@@ -65,13 +65,6 @@ jobs:
         run: |
           composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
           vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github
-
-      # see https://github.com/marketplace/actions/action-scrutinizer
-      - name: Upload code coverage to scrutinizer
-        uses: sudo-bot/action-scrutinizer@latest
-        with:
-          cli-args: "--format=php-clover build/coverage-clover.xml"
-        continue-on-error: true
 
   build:
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,6 +13,7 @@ build:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-
-tools:
-  external_code_coverage: true
+          - command: vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
+            coverage:
+              file: coverage.clover
+              format: clover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ tools/php-cs-fixer fix -v --dry-run
 vendor/bin/phpunit --testdox
 tools/phpstan analyze
 tools/psalm
-phpdbg -qrr tools/infection --show-mutations
+tools/infection --show-mutations
 ```
 
 ## Running GitHub Actions locally

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If your known values array constains an array with string keys or a standard obj
 
 Even when PHP supports method with different case, this class use exact case, so `getSomething()` is different
 from `getSomeThing()`. The only transformation made to locate the key/property is to lower first char, then
-`getSomething()` will lookup for `something` into local value. Anyhow, you can override the method
+`getSomething()` will look up for `something` into local value. Anyhow, you can override the method
 `getEntryValueWithKey(string $key): mixed` to perform other transformation on key/property name.
 
 ### Extending

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run phplint, dev:check-style, phpunit, phpstan and psalm",
+        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan, psalm and infection",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:infection": "DEV: run mutation tests using infection"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,18 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## Unreleased 2021-09-25
+
+Fixed CI. Infection fails because it is not working on PHP 7.4.
+PHPUnit cannot create code coverage for infection on PHP 8.0; so, upgrade to PHP 8.0 is not a solution.
+Install and run Infection throught Composer is the right workaround.
+
+## Unreleased 2021-06-18
+
+Fix description on `composer dev:build`.
+
+PHPUnit should not be verbose by default.
+
 ## Unreleased 2021-06-17
 
 Migrate from Travis-CI to GitHub Actions. Thanks Travis-CI!

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ Install and run Infection throught Composer is the right workaround.
 
 Remove unused extensions on GitHub Actions.
 
+Move code coverage generation to Scrutinizer.
+
 ## Unreleased 2021-06-18
 
 Fix description on `composer dev:build`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ Fixed CI. Infection fails because it is not working on PHP 7.4.
 PHPUnit cannot create code coverage for infection on PHP 8.0; so, upgrade to PHP 8.0 is not a solution.
 Install and run Infection throught Composer is the right workaround.
 
+Remove unused extensions on GitHub Actions.
+
 ## Unreleased 2021-06-18
 
 Fix description on `composer dev:build`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,7 +37,7 @@ Maintenance on development environment, didn't change any source inside `src/`.
 
 ## Version 0.1.2 2020-01-13
 
-- Fix phpdoc on `MicroCatalog::getEntriesArray()`, the return type was defining key type but it shouldn't.
+- Fix phpdoc on `MicroCatalog::getEntriesArray()`, the return type was defining key type, but it shouldn't.
 - Do not include in distribution package folder `/develop`
 
 ## Version 0.1.1 2020-01-09

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,8 +3,7 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     cacheResultFile="build/phpunit.result.cache"
     bootstrap="tests/bootstrap.php"
-    executionOrder="depends,defects"
-    verbose="true">
+    executionOrder="depends,defects">
   <testsuites>
     <testsuite name="default">
       <directory>tests</directory>


### PR DESCRIPTION
Infection as phar is not running on PHP 7.4.
This PR install and use infection as a dev dependency as a workaround